### PR TITLE
Updated to build against any version of Spark 1.4.0 and later.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,18 +2,45 @@ name := "SparkTreeInterpreter"
 
 version := "1.0.1"
 
-scalaVersion := "2.10.5"
+//sparkVersion := "1.4.0"
+//sparkVersion := "1.6.0"
+sparkVersion := "2.0.0"
+
+scalaVersion := {
+  if (sparkVersion.value >= "2.0.0") {
+    "2.11.8"
+  } else {
+    "2.10.6"
+  }
+}
 
 resolvers += Resolver.mavenLocal
 
+val sparkTestingBaseVersion = "0.4.7"
+
+sparkComponents := Seq("core", "sql", "mllib")
+
 libraryDependencies ++= Seq(
-  "org.apache.spark" %% "spark-core" % "1.6.0",
-  "org.apache.spark" %% "spark-mllib" % "1.6.0",
   "com.twitter" %% "algebird-core" % "0.9.0",
   "org.scalaz" %% "scalaz-core" % "7.1.0",
-  "org.scalatest" %% "scalatest"  % "2.2.4" % "test",
-  "com.holdenkarau" %% "spark-testing-base" % "1.5.0_0.1.3",
+  "com.holdenkarau" %% "spark-testing-base" % s"${sparkVersion.value}_$sparkTestingBaseVersion",
   "org.json4s" %% "json4s-native" % "3.2.10",
   "org.json4s" %% "json4s-jackson" % "3.2.10",
-  "org.json4s" % "json4s-ext_2.10" % "3.2.10"
+  "org.json4s" %% "json4s-ext" % "3.2.10"
 )
+
+unmanagedSourceDirectories in Compile := {
+  if (sparkVersion.value >= "2.0.0") {
+    Seq((sourceDirectory in Compile) (_ / ("scala"))).join.value
+  } else {
+    Seq((sourceDirectory in Compile) (_ / ("scala-2.10"))).join.value
+  }
+}
+
+unmanagedSourceDirectories in Test := {
+  if (sparkVersion.value >= "2.0.0") {
+    Seq((sourceDirectory in Test) (_ / ("scala"))).join.value
+  } else {
+    Seq((sourceDirectory in Test) (_ / ("scala-2.10"))).join.value
+  }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,5 @@
-logLevel := Level.Warn
+logLevel := Level.Info
+
+resolvers += "bintray-spark-packages" at "https://dl.bintray.com/spark-packages/maven/"
+
+addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.5")

--- a/src/main/scala/treeinterpreter/DressedTree.scala
+++ b/src/main/scala/treeinterpreter/DressedTree.scala
@@ -1,0 +1,84 @@
+package treeinterpreter
+
+import org.apache.spark.mllib.linalg.Vector
+import org.apache.spark.mllib.tree.configuration.Algo._
+import org.apache.spark.mllib.tree.model.{DecisionTreeModel, Node}
+import treeinterpreter.DressedTree._
+import treeinterpreter.TreeNode._
+
+case class DressedTree(model: DecisionTreeModel, bias: Double, contributionMap: NodeContributions) {
+
+  implicit def nodeType(node: Node): TreeNode = model.algo match {
+    case Classification => ClassificationNode(node)
+    case Regression => RegressionNode(node)
+  }
+
+  private def predictLeafID(features: Vector): NodeID = model.topNode.predictLeaf(features)
+
+  def predictLeaf(point: Vector): Interp = {
+    val leaf = predictLeafID(point)
+    val prediction = model.predict(point)
+    val contribution = contributionMap(leaf)
+    Interp(bias, prediction, contribution)
+  }
+
+  def interpret(point: Vector) = predictLeaf(point)
+}
+
+
+object DressedTree {
+
+  type Feature = Option[NodeID]
+
+  type NodeContributions = Map[NodeID, Map[Feature, Double]]
+
+  def arrayprint[A](x: Array[A]): Unit = println(x.deep.mkString("\n"))
+
+  def trainInterpreter(model: DecisionTreeModel): DressedTree = {
+    val topNode = model.topNode
+
+    implicit def nodeType(node: Node): TreeNode = model.algo match {
+      case Classification => ClassificationNode(node)
+      case Regression => RegressionNode(node)
+    }
+    type Path = Array[TreeNode]
+
+    type PathBundle = Array[Path]
+
+    val bias = topNode.value
+
+    var Paths: PathBundle = Array()
+
+    def buildPath(paths: Path, node: Node): PathBundle = {
+      val TreeNode = nodeType(node)
+      if (node.isLeaf) Array(paths :+ TreeNode)
+      else {
+        import node._
+        val buildRight = buildPath(paths :+ TreeNode, rightNode.get)
+        val buildLeft = buildPath(paths :+ TreeNode, leftNode.get)
+        buildRight ++ buildLeft
+      }
+    }
+
+    val paths = buildPath(Array(), topNode).map(_.sorted.reverse)
+    DressedTree.arrayprint(paths)
+
+    val contributions: NodeContributions = paths.flatMap(path => {
+
+      val contribMap = {
+        {path zip path.tail
+        }.flatMap {
+          case (currentNode, prevNode) =>
+            Map(prevNode.feature -> {
+              currentNode.value -prevNode.value
+            })
+        }
+      }.foldLeft(Map[Feature, Double]())(_ + _)
+
+      val leafID = path.head.NodeID
+      Map(leafID -> contribMap)
+    }).toMap
+
+    DressedTree(model, bias, contributions)
+  }
+}

--- a/src/main/scala/treeinterpreter/Interpret.scala
+++ b/src/main/scala/treeinterpreter/Interpret.scala
@@ -1,0 +1,64 @@
+package treeinterpreter
+
+import com.twitter.algebird
+import com.twitter.algebird.Monoid
+import com.twitter.algebird.Operators._
+import org.apache.spark.mllib.regression.LabeledPoint
+import org.apache.spark.mllib.tree.model.{DecisionTreeModel, RandomForestModel}
+import org.apache.spark.rdd.RDD
+import treeinterpreter.DressedTree.Feature
+
+case class Interp(bias: Double, prediction: Double, contributions: Map[Feature, Double], treeCount: Double = 1.0, checksum: Double = 0.0) {
+  override def toString(): String = {
+    s"""
+   | bias: $bias
+   | prediction: $prediction
+   | contributionMap $contributions
+   | sumOfTerms: $checksum""".stripMargin
+  }
+}
+
+object Interp {
+
+  class InterpMonoid extends Monoid[Interp] {
+    def plus(l: Interp, r: Interp) = new Interp(
+      l.bias + r.bias,
+      l.prediction + r.prediction,
+      l.contributions + r.contributions,
+      l.treeCount + r.treeCount)
+
+    def zero = Interp(0.0, 0.0, Map())
+  }
+
+  implicit def InterpMonoidImpl: algebird.Monoid[Interp] = new InterpMonoid
+
+  def interpretModel(rf: RandomForestModel, testSet: RDD[LabeledPoint]): RDD[Interp] = {
+    val trees = rf.trees.map(tree => DressedTree.trainInterpreter(tree))
+
+    val result = testSet.map(lp => {
+      trees.map { case dressedTree =>
+        dressedTree.interpret(lp.features)
+      }
+    })
+
+    val aggResult: RDD[Interp] = result
+      .map(_.reduce(_ + _))
+      .map { case interp => {
+        import interp._
+        val (avgBias, avgPrediction) = (bias / treeCount, prediction / treeCount)
+
+        val avgContributions = contributions.mapValues(_/treeCount).map(identity)
+
+        val checkSum = avgBias + avgContributions.values.sum
+
+        Interp(avgBias, avgPrediction, avgContributions, treeCount,checkSum)
+      }
+    }
+    aggResult
+  }
+
+  def interpretModel(model: DecisionTreeModel, testSet: RDD[LabeledPoint]): RDD[Interp] = {
+    val dressedTree = DressedTree.trainInterpreter(model)
+    testSet.map(lp => dressedTree.interpret(lp.features))
+  }
+}

--- a/src/main/scala/treeinterpreter/TreeNode.scala
+++ b/src/main/scala/treeinterpreter/TreeNode.scala
@@ -1,0 +1,63 @@
+package treeinterpreter
+
+import org.apache.spark.mllib.linalg.Vector
+import org.apache.spark.mllib.tree.configuration.FeatureType._
+import org.apache.spark.mllib.tree.model.Node
+
+object TreeNode {
+
+  type NodeID = Int
+  type NodeMap = Map[NodeID, Double]
+
+  trait SimplifiedNode {
+    def NodeID: NodeID
+
+    def predictLeaf(features: Vector)(implicit node2Treenode: Node => TreeNode): Int
+
+    def value: Double
+
+    def feature: Option[Int]
+  }
+
+  abstract class TreeNode(node: Node) extends SimplifiedNode with Ordered[TreeNode] {
+    import node._
+
+    override def toString(): String = Array(id, value, feature).mkString("||", ",", "||")
+
+    def compare(that: TreeNode) =  this.NodeID compare that.NodeID
+
+    val NodeID: Int = id
+
+    val feature: Option[Int] = split.map(_.feature)
+
+    def value: Double
+
+    def predictLeaf(features: Vector)(implicit node2Treenode: Node => TreeNode): NodeID = {
+      if (isLeaf) {
+        id
+      } else {
+        if (split.get.featureType == Continuous) {
+          if (features(split.get.feature) <= split.get.threshold) {
+            leftNode.get.predictLeaf(features)
+          } else {
+            rightNode.get.predictLeaf(features)
+          }
+        } else {
+          if (split.get.categories.contains(features(split.get.feature))) {
+            leftNode.get.predictLeaf(features)
+          } else {
+            rightNode.get.predictLeaf(features)
+          }
+        }
+      }
+    }
+  }
+
+  case class ClassificationNode(node: Node) extends TreeNode(node: Node) {
+    override def value: Double = node.predict.prob + .00001 // because algebird MapMonoid discards 0 values
+  }
+
+  case class RegressionNode(node: Node) extends TreeNode(node: Node) {
+    override def value: Double = node.predict.predict
+  }
+}

--- a/src/main/scala/treeinterpreter/utils/JsonString.scala
+++ b/src/main/scala/treeinterpreter/utils/JsonString.scala
@@ -1,0 +1,10 @@
+package treeinterpreter.utils
+
+import org.json4s.jackson.Serialization._
+
+trait toJsonString {
+  override def toString = {
+    implicit val formats = org.json4s.DefaultFormats
+    write(this)
+  }
+}

--- a/src/test/scala/TestTreeInterpreter.scala
+++ b/src/test/scala/TestTreeInterpreter.scala
@@ -1,0 +1,77 @@
+import com.holdenkarau.spark.testing.LocalSparkContext
+import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.mllib.regression.LabeledPoint
+import org.apache.spark.mllib.tree.RandomForest
+import org.apache.spark.{SparkConf, SparkContext}
+import org.scalatest.{BeforeAndAfterAll, FunSuite, Suite}
+import treeinterpreter.Interp
+
+class InterpTest extends FunSuite with SharedSparkContext {
+  test("Random Forest Regression Test") {
+
+    implicit val _sc = sc
+
+    val currentDir = System.getProperty("user.dir")
+    val replacementPath = s"$currentDir/src/test/resources/bostonData.data"
+    val data = _sc.textFile(replacementPath)
+
+    val parsedData = data.map(line => {
+      val parsedLine = line.split(',')
+      LabeledPoint(parsedLine.last.toDouble, Vectors.dense(parsedLine.dropRight(1).map(_.toDouble)))
+    })
+
+    val splits = parsedData.randomSplit(Array(0.2, 0.8), seed = 5)
+    val (trainingData, testData) = (splits(0), splits(1))
+
+    val numClasses = 2
+    val categoricalFeaturesInfo = Map[Int, Int]()
+    val numTrees = 10
+    val featureSubsetStrategy = "auto"
+    val impurity = "variance"
+    val maxDepth = 2
+    val maxBins = 32
+
+    val classimpurity = "gini"
+
+    val rf = RandomForest.trainRegressor(trainingData, categoricalFeaturesInfo,
+      numTrees, featureSubsetStrategy, impurity, maxDepth, maxBins, seed = 21)
+
+        val labelsAndPredictions = trainingData.map { point =>
+          val prediction = rf.predict(point.features)
+          (point.label, prediction)
+        }
+
+    val testMSE = math.sqrt(labelsAndPredictions.map { case (v, p) => math.pow(v - p, 2) }.mean())
+
+    println("Test Mean Squared Error = " + testMSE)
+
+    val interpRDD = Interp.interpretModel(rf, trainingData)
+
+    interpRDD.collect().foreach(println)
+
+    interpRDD.collect().foreach(item=> assert(scala.math.abs(item.checksum/item.prediction-1)<.2))
+  }
+}
+
+trait SharedSparkContext extends BeforeAndAfterAll {
+  self: Suite =>
+
+  @transient private var _sc: SparkContext = _
+
+  implicit def sc: SparkContext = _sc
+
+  val conf = new SparkConf().setMaster("local[*]")
+    .setAppName("test")
+
+
+  override def beforeAll() {
+    _sc = new SparkContext(conf)
+    super.beforeAll()
+  }
+
+  override def afterAll() {
+    LocalSparkContext.stop(_sc)
+    _sc = null
+    super.afterAll()
+  }
+}


### PR DESCRIPTION
Updated to build against any version of Spark 1.4.0 and later. Tested against 1.4.0, 1.6.0, and 2.0.0.

Please note I made a copy of the original source from `src/scala-2.10` in `src/scala`. Spark 2.0+ uses Scala 2.11. Future work will need to be mirrored between the two unless we know we're not going to use any 2.11 specific features. 

An alternative way of handling this would be to have Spark version based source folders. Ex:`src/v2.0`, `src/v1.x`, which could be used to account for both Scala *and* Spark version differences.